### PR TITLE
missing closing div in theme

### DIFF
--- a/theme/islandora-markup-editor.tpl.php
+++ b/theme/islandora-markup-editor.tpl.php
@@ -56,5 +56,6 @@
         </div>
       </div>
       <div id="east_div" class="ui-layout-east"></div>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
We found a missing closing div element in the Markup Editor theme file which was causing our sidebar navigation panel to display under the CWRC-Writer.  We are using a modified version of the zen theme.  
